### PR TITLE
Allow user to override keepalive on connect

### DIFF
--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -102,9 +102,11 @@ class MQTTClient(object):
         # Skip calling connect if already connected.
         if self._connected:
             return
+        # If given, use user-provided keepalive, otherwise default to KEEP_ALIVE_SEC
+        keepalive = kwargs.pop('keepalive', KEEP_ALIVE_SEC)
         # Connect to the Adafruit IO MQTT service.
         self._client.connect(self._service_host, port=self._service_port,
-            keepalive=KEEP_ALIVE_SEC, **kwargs)
+            keepalive=keepalive, **kwargs)
 
     def is_connected(self):
         """Returns True if connected to Adafruit.IO and False if not connected.


### PR DESCRIPTION
The `keepalive` is always set to `KEEP_ALIVE_SEC` and cannot be overridden by the user. This fix uses the user-provided `keepalive` from `kwargs`  and defaults to `KEEP_ALIVE_SEC` if there is None.
This fixes #28
