### PR TITLE
break out errors into explicit types

### DIFF
--- a/Adafruit_IO/errors.py
+++ b/Adafruit_IO/errors.py
@@ -21,6 +21,14 @@
 
 import json
 
+# MQTT RC Error Types
+MQTT_ERRORS   = [ 'Connection successful',
+                  'Incorrect protocol version',
+                  'Invalid Client ID',
+                  'Server unavailable ',
+                  'Bad username or password',
+                  'Not authorized' ]
+
 class AdafruitIOError(Exception):
     """Base class for all Adafruit IO request failures."""
     pass
@@ -49,3 +57,11 @@ class ThrottlingError(AdafruitIOError):
         super(ThrottlingError, self).__init__("Exceeded the limit of Adafruit IO "  \
             "requests in a short period of time. Please reduce the rate of requests " \
             "and try again later.")
+
+class MQTTError(Exception):
+    """Handles connection attempt failed errors.
+    """
+    def __init__(self, response):
+        error = MQTT_ERRORS[response]
+        super(MQTTError, self).__init__(error)
+    pass

--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -35,7 +35,7 @@ class MQTTClient(object):
     using the MQTT protocol.
     """
 
-    def __init__(self, username, key, service_host='io.adafruit.com', service_port=8883):
+    def __init__(self, username, key, service_host='io.adafruit.com', service_port=1883):
         """Create instance of MQTT client.
 
         Required parameters:
@@ -52,7 +52,6 @@ class MQTTClient(object):
         self.on_message    = None
         # Initialize MQTT client.
         self._client = mqtt.Client()
-        self._client.tls_set_context() # mqqts
         self._client.username_pw_set(username, key)
         self._client.on_connect    = self._mqtt_connect
         self._client.on_disconnect = self._mqtt_disconnect

--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -21,7 +21,8 @@
 import logging
 
 import paho.mqtt.client as mqtt
-
+import sys
+from .errors import MQTTError, RequestError
 
 # How long to wait before sending a keep alive (paho-mqtt configuration).
 KEEP_ALIVE_SEC = 60  # One minute
@@ -62,11 +63,12 @@ class MQTTClient(object):
         # Check if the result code is success (0) or some error (non-zero) and
         # raise an exception if failed.
         if rc == 0:
+            #raise RequestError(rc)
             self._connected = True
+            print('Connected to Adafruit IO!')
         else:
-            # TODO: Make explicit exception classes for these failures:
-            # 0: Connection successful 1: Connection refused - incorrect protocol version 2: Connection refused - invalid client identifier 3: Connection refused - server unavailable 4: Connection refused - bad username or password 5: Connection refused - not authorised 6-255: Currently unused.
-            raise RuntimeError('Error connecting to Adafruit IO with rc: {0}'.format(rc))
+            # handle RC errors within `errors.py`'s MQTTError class
+            raise MQTTError(rc)
         # Call the on_connect callback if available.
         if self.on_connect is not None:
             self.on_connect(self)
@@ -78,7 +80,8 @@ class MQTTClient(object):
         # log the RC as an error.  Continue on to call any disconnect handler
         # so clients can potentially recover gracefully.
         if rc != 0:
-            logger.debug('Unexpected disconnect with rc: {0}'.format(rc))
+            raise MQTTError(rc)
+        print('Disconnected from Adafruit IO!')
         # Call the on_disconnect callback if available.
         if self.on_disconnect is not None:
             self.on_disconnect(self)

--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -35,29 +35,24 @@ class MQTTClient(object):
     using the MQTT protocol.
     """
 
-    def __init__(self, username, key, service_host='io.adafruit.com', secure=True):
+    def __init__(self, username, key, service_host='io.adafruit.com', service_port=8883):
         """Create instance of MQTT client.
 
-            :param username: Adafruit.IO Username for your account.
-            :param key: Adafruit IO access key (AIO Key) for your account.
-            :param secure: (optional, boolean) Switches secure/insecure connections
+        Required parameters:
+        - username: The Adafruit.IO username for your account (found on the
+                    accounts site https://accounts.adafruit.com/).
+        - key: The Adafruit.IO access key for your account.
         """
         self._username = username
         self._service_host = service_host
-        if secure:
-            self._service_port = 8883
-        elif not secure:
-            self._service_port = 1883
+        self._service_port = service_port
         # Initialize event callbacks to be None so they don't fire.
         self.on_connect    = None
         self.on_disconnect = None
         self.on_message    = None
         # Initialize MQTT client.
         self._client = mqtt.Client()
-        if secure:
-            self._client.tls_set_context()
-        elif not secure:
-            print('**THIS CONNECTION IS INSECURE** SSL/TLS not supported for this platform')
+        self._client.tls_set_context() # mqqts
         self._client.username_pw_set(username, key)
         self._client.on_connect    = self._mqtt_connect
         self._client.on_disconnect = self._mqtt_disconnect

--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -35,24 +35,29 @@ class MQTTClient(object):
     using the MQTT protocol.
     """
 
-    def __init__(self, username, key, service_host='io.adafruit.com', service_port=8883):
+    def __init__(self, username, key, service_host='io.adafruit.com', secure=True):
         """Create instance of MQTT client.
 
-        Required parameters:
-        - username: The Adafruit.IO username for your account (found on the
-                    accounts site https://accounts.adafruit.com/).
-        - key: The Adafruit.IO access key for your account.
+            :param username: Adafruit.IO Username for your account.
+            :param key: Adafruit IO access key (AIO Key) for your account.
+            :param secure: (optional, boolean) Switches secure/insecure connections
         """
         self._username = username
         self._service_host = service_host
-        self._service_port = service_port
+        if secure:
+            self._service_port = 8883
+        elif not secure:
+            self._service_port = 1883
         # Initialize event callbacks to be None so they don't fire.
         self.on_connect    = None
         self.on_disconnect = None
         self.on_message    = None
         # Initialize MQTT client.
         self._client = mqtt.Client()
-        self._client.tls_set_context() # mqqts
+        if secure:
+            self._client.tls_set_context()
+        elif not secure:
+            print('**THIS CONNECTION IS INSECURE** SSL/TLS not supported for this platform')
         self._client.username_pw_set(username, key)
         self._client.on_connect    = self._mqtt_connect
         self._client.on_disconnect = self._mqtt_disconnect

--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -35,7 +35,7 @@ class MQTTClient(object):
     using the MQTT protocol.
     """
 
-    def __init__(self, username, key, service_host='io.adafruit.com', service_port=1883):
+    def __init__(self, username, key, service_host='io.adafruit.com', service_port=8883):
         """Create instance of MQTT client.
 
         Required parameters:
@@ -52,6 +52,7 @@ class MQTTClient(object):
         self.on_message    = None
         # Initialize MQTT client.
         self._client = mqtt.Client()
+        self._client.tls_set_context() # mqqts
         self._client.username_pw_set(username, key)
         self._client.on_connect    = self._mqtt_connect
         self._client.on_disconnect = self._mqtt_disconnect


### PR DESCRIPTION
Addressing: https://github.com/adafruit/io-client-python/issues/18
> In particular break out connection attempt failed errors (non-zero RC in connect callback), and the disconnect errors (non-zero RC in disconnect callback) into explicit error types that inherit from a common error base. This way it's easier to catch errors like unexpected disconnects and retry connecting to the service.

Impl.: Broke out another error class for RC errors (MQTTERROR) in `errors.py`, made a list of errors (so we can add more into IO, #6-255 are unassigned), called in `mqtt_client.py`.

