### PR TITLE
PR: Secure MQTT Implementation

### DIFF
--- a/examples/mqtt/mqtt_client.py
+++ b/examples/mqtt/mqtt_client.py
@@ -39,10 +39,10 @@ def message(client, feed_id, payload):
 
 
 # Create a SECURE MQTT client instance
-# Note: This client will always be secure, an optional parameter can be added
+# Note: This client will default to secure, an optional parameter can be added
 # to make it insecure, comment out the below line
 # client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY, secure=False)
-client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY, secure=False)
+client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY)
 
 # Setup the callback functions defined above.
 client.on_connect    = connected

--- a/examples/mqtt/mqtt_client.py
+++ b/examples/mqtt/mqtt_client.py
@@ -38,8 +38,11 @@ def message(client, feed_id, payload):
     print('Feed {0} received new value: {1}'.format(feed_id, payload))
 
 
-# Create an MQTT client instance.
-client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY)
+# Create a SECURE MQTT client instance
+# Note: This client will always be secure, an optional parameter can be added
+# to make it insecure, comment out the below line
+# client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY, secure=False)
+client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY, secure=False)
 
 # Setup the callback functions defined above.
 client.on_connect    = connected


### PR DESCRIPTION
Ref. Issue: https://github.com/adafruit/io-client-python/issues/5

_Changes:_
- mqtt_client now **defaults to secure MQTT**, port 8883 (TLS/SSL):
`def __init__(self, username, key, service_host='io.adafruit.com', secure=True):
`

- For users who wish to use an insecure connection (router/network troubles), we'll support that too! Just add a `secure = false` parameter when the client instance is created: 
`client = MQTTClient(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY, **secure=False**)
`

- Insecure client connections return a console warning, connect on port 1883.

- Modified MQTT example to show both secure **and** insecure client connections. 
